### PR TITLE
D8CORE-2228: adding the nav and aria tag so menu show in Landmarks menu

### DIFF
--- a/templates/block/block--menu-block--person-type.html.twig
+++ b/templates/block/block--menu-block--person-type.html.twig
@@ -42,15 +42,18 @@
 {% set menu_class = 'person-category__collapsable-menu' %}
 {% set heading_id = (configuration.id ~ '-menu')|clean_id %}
 {% set attributes = attributes.setAttribute('id', heading_id) %}
+{% set button_label = ('button-label')|clean_id %}
+{% set attributes = attributes.setAttribute('aria-labelledby', button_label) %}
+{% set button_id = ('button-label')|clean_id %}
 {% set attributes = attributes.addClass(classes) %}
 
-<nav{{ attributes }} aria-labelledby="button-label">
+<nav{{ attributes }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
-  <button{{ title_attributes.setAttribute('class', menu_class) }} id="button-label">
+  <button{{ title_attributes.setAttribute('class', menu_class).setAttribute('id', button_id) }}>
     {{ configuration.label }}
     <span class="su-link su-link--jump"></span>
   </button>

--- a/templates/block/block--menu-block--person-type.html.twig
+++ b/templates/block/block--menu-block--person-type.html.twig
@@ -44,13 +44,13 @@
 {% set attributes = attributes.setAttribute('id', heading_id) %}
 {% set attributes = attributes.addClass(classes) %}
 
-<div{{ attributes }}>
+<nav{{ attributes }} aria-labelledby="button-label">
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
-  <button{{ title_attributes.setAttribute('class', menu_class) }}>
+  <button{{ title_attributes.setAttribute('class', menu_class) }} id="button-label">
     {{ configuration.label }}
     <span class="su-link su-link--jump"></span>
   </button>
@@ -60,4 +60,4 @@
   {% block content %}
     {{ content }}
   {% endblock %}
-</div>
+</nav>

--- a/templates/block/block--menu-block--person-type.html.twig
+++ b/templates/block/block--menu-block--person-type.html.twig
@@ -44,7 +44,6 @@
 {% set attributes = attributes.setAttribute('id', heading_id) %}
 {% set button_label = ('button-label')|clean_id %}
 {% set attributes = attributes.setAttribute('aria-labelledby', button_label) %}
-{% set button_id = ('button-label')|clean_id %}
 {% set attributes = attributes.addClass(classes) %}
 
 <nav{{ attributes }}>
@@ -53,7 +52,7 @@
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
-  <button{{ title_attributes.setAttribute('class', menu_class).setAttribute('id', button_id) }}>
+  <button{{ title_attributes.setAttribute('class', menu_class).setAttribute('id', button_label) }}>
     {{ configuration.label }}
     <span class="su-link su-link--jump"></span>
   </button>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This is for accessibility. I changed a div to nav for the filter menu. I also added an aria-labelledby to get the menu into the Landmarks menu in VoiceOver.  

# Review By (Date)
- Thursday

# Criticality
- It effects all the accelerants - Person, News, Alerts.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch on the Person, News, and Alerts Modules.
2. Clear the cache.
3. go to the listing pages.
3. Verify the Filter menu appears in the Landmarks menu in VoiceOver.  The menu name changes based on the button label.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- D8CORE-2228
- One for each module.
https://github.com/SU-SWS/stanford_news/pull/86
https://github.com/SU-SWS/stanford_events/pull/10
https://github.com/SU-SWS/stanford_person/pull/95
- @cjwest 

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
