### PR TITLE
D8CORE-000 Adjusted regext to retain numbers in workgroups and org codes

### DIFF
--- a/modules/stanford_person_importer/src/Cap.php
+++ b/modules/stanford_person_importer/src/Cap.php
@@ -156,7 +156,7 @@ class Cap implements CapInterface {
    * {@inheritDoc}
    */
   public function getOrganizationUrl($organizations, $children = FALSE) {
-    $organizations = preg_replace('/[^A-Z,]/', '', strtoupper($organizations));
+    $organizations = preg_replace('/[^A-Z,0-9]/', '', strtoupper($organizations));
     $url = self::CAP_URL . "?orgCodes=$organizations";
     if ($children) {
       $url .= '&includeChildren=true';
@@ -168,7 +168,7 @@ class Cap implements CapInterface {
    * {@inheritDoc}
    */
   public function getWorkgroupUrl($workgroups) {
-    $workgroups = preg_replace('/[^A-Z,:\-_]/', '', strtoupper($workgroups));
+    $workgroups = preg_replace('/[^A-Z,:\-_0-9]/', '', strtoupper($workgroups));
     return self::CAP_URL . "?privGroups=$workgroups";
   }
 

--- a/modules/stanford_person_importer/tests/src/Unit/CapTest.php
+++ b/modules/stanford_person_importer/tests/src/Unit/CapTest.php
@@ -220,4 +220,12 @@ class CapTest extends UnitTestCase {
     return $response;
   }
 
+  /**
+   * Retain the numbers in the workgroups and organizations.
+   */
+  public function testNumbers() {
+    $this->assertContains('FOO:BAR123', $this->service->getWorkgroupUrl('foo:bar123'));
+    $this->assertContains('FOOBAR123', $this->service->getOrganizationUrl('foo:bar123'));
+  }
+
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adjusted regext to retain numbers in workgroups and org codes

# Need Review By (Date)
- 9/3

# Urgency
- high

# Steps to Test
1. Checkout this branch
1. use a workgroup with a number like `bioe:phd7` and run the migration importer
1. verify you get the correct profiles imported

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
