### PR TITLE
D8CORE-2535: Change sort on interior pages to be by last name then first

### DIFF
--- a/config/install/views.view.stanford_person_list_terms_first.yml
+++ b/config/install/views.view.stanford_person_list_terms_first.yml
@@ -503,10 +503,10 @@ display:
           entity_type: taxonomy_term
           entity_field: weight
           plugin_id: standard
-        su_person_first_name_value:
-          id: su_person_first_name_value
-          table: node__su_person_first_name
-          field: su_person_first_name_value
+        su_person_last_name_value:
+          id: su_person_last_name_value
+          table: node__su_person_last_name
+          field: su_person_last_name_value
           relationship: reverse__node__su_person_type_group
           group_type: group
           admin_label: ''
@@ -515,10 +515,10 @@ display:
           expose:
             label: ''
           plugin_id: standard
-        su_person_last_name_value:
-          id: su_person_last_name_value
-          table: node__su_person_last_name
-          field: su_person_last_name_value
+        su_person_first_name_value:
+          id: su_person_first_name_value
+          table: node__su_person_first_name
+          field: su_person_first_name_value
           relationship: reverse__node__su_person_type_group
           group_type: group
           admin_label: ''


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed sorting on interior people pages to sort by last name then first name

# Review By (Date)
- Sept 3rd?

# Criticality
- 3/10

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Check out branch D8CORE-2535 of the profile
3. Import config (drush cim)
4. Clear all caches
5. Ensure sort order is correct by creating and placing a few sample profiles in a group

