### PR TITLE
D8CORE-2470 Use the default image on any imported content without an image

### DIFF
--- a/modules/stanford_person_importer/stanford_person_importer.module
+++ b/modules/stanford_person_importer/stanford_person_importer.module
@@ -96,7 +96,7 @@ function stanford_person_importer_field_widget_form_alter(&$element, FormStateIn
  */
 function stanford_person_importer_node_presave(NodeInterface $entity) {
   // Don't worry about nodes that were manually created or if the field is gone.
-  if(!_stanford_person_importer_node_imported($entity) || !$entity->hasField('su_person_photo')){
+  if (!_stanford_person_importer_node_imported($entity) || !$entity->hasField('su_person_photo')) {
     return;
   }
   $photo_values = $entity->get('su_person_photo')->getValue();

--- a/modules/stanford_person_importer/stanford_person_importer.module
+++ b/modules/stanford_person_importer/stanford_person_importer.module
@@ -89,6 +89,33 @@ function stanford_person_importer_field_widget_form_alter(&$element, FormStateIn
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * Before saving imported nodes, set the photo field to a default value if it
+ * doesn't have any legitimate media items.
+ */
+function stanford_person_importer_node_presave(NodeInterface $entity) {
+  // Don't worry about nodes that were manually created or if the field is gone.
+  if(!_stanford_person_importer_node_imported($entity) || !$entity->hasField('su_person_photo')){
+    return;
+  }
+  $photo_values = $entity->get('su_person_photo')->getValue();
+  $media_storage = \Drupal::entityTypeManager()->getStorage('media');
+  foreach ($photo_values as $value) {
+    // If any delta value has a valid media entity, we don't need to set the
+    // default field value.
+    if ($media_storage->load($value['target_id'])) {
+      return;
+    }
+  }
+
+  $default_photo = $entity->getFieldDefinition('su_person_photo')
+    ->getDefaultValue($entity);
+  // Set the default value of the photo field.
+  $entity->set('su_person_photo', $default_photo);
+}
+
+/**
  * Implements hook_entity_field_access().
  */
 function stanford_person_importer_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
@@ -113,7 +140,7 @@ function stanford_person_importer_entity_field_access($operation, FieldDefinitio
     // The field or a column of the field was mapped with data from migrate.
     // Mark it as forbidden.
     if ($processing || $migration_config->get("process.$field_name")) {
-      return AccessResult::forbidden(t('Field is mapped by the importer'));
+      return AccessResult::forbidden((string) t('Field is mapped by the importer'));
     }
   }
   return AccessResult::neutral();

--- a/modules/stanford_person_importer/stanford_person_importer.post_update.php
+++ b/modules/stanford_person_importer/stanford_person_importer.post_update.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * stanford_person_importer.post_update.php
+ */
+
+/**
+ * Invalidate all migration profiles that don't have a photo.
+ */
+function stanford_person_importer_post_update_8001(&$sandbox) {
+  if (!\Drupal::database()
+    ->schema()
+    ->tableExists('migrate_map_su_stanford_person')) {
+    return;
+  }
+
+  $nids = \Drupal::entityTypeManager()->getStorage('node')
+    ->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('type', 'stanford_person')
+    ->condition('su_person_photo', NULL, 'IS NULL')
+    ->execute();
+
+  \Drupal::database()->update('migrate_map_su_stanford_person')
+    ->fields(['hash' => ''])
+    ->condition('destid1', array_values($nids), 'IN')
+    ->execute();
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Before an imported node is saved, check for a valid photo media item. If none exists, use the field's default value.

# Need Review By (Date)
- 10/16

# Urgency
- low

# Steps to Test
1. Checkout this branch
1. clear cache
1. import a profile from CAP that doesn't have an image.
1. manually delete the field's value on the profile node. (use devel or just delete from the database tables)
1. run importer again `drush mim su_stanford_person --update`
1. validate the default field value is on the profile.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
