### PR TITLE
D8CORE-2664: Delete 1x1 profile images and invalidate the content to reimport

### DIFF
--- a/modules/stanford_person_importer/stanford_person_importer.post_update.php
+++ b/modules/stanford_person_importer/stanford_person_importer.post_update.php
@@ -29,3 +29,52 @@ function stanford_person_importer_post_update_8001(&$sandbox) {
       ->execute();
   }
 }
+
+/**
+ * Delete imported images that are only 1px x 1px.
+ */
+function stanford_person_importer_post_update_8002(&$sandbox) {
+  if (!\Drupal::database()
+    ->schema()
+    ->tableExists('migrate_map_su_stanford_person')) {
+    return;
+  }
+  $media_storage = \Drupal::entityTypeManager()->getStorage('media');
+  $mids = $media_storage->getQuery()
+    ->condition('bundle', 'image')
+    ->condition('field_media_image.width', 2, '<')
+    ->condition('field_media_image.height', 2, '<')
+    ->execute();
+  if (empty($mids)) {
+    return;
+  }
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+  $nids = $node_storage->getQuery()
+    ->condition('su_person_photo', $mids, 'IN')
+    ->execute();
+  if (empty($nids)) {
+    return;
+  }
+
+  /** @var \Drupal\node\NodeInterface $node */
+  foreach ($node_storage->loadMultiple($nids) as $node) {
+    $field_default = $node->getFieldDefinition('su_person_photo')
+      ->getDefaultValue($node);
+    $node->set('su_person_photo', $field_default)->save();
+  }
+
+  \Drupal::database()->update('migrate_map_su_stanford_person')
+    ->fields(['hash' => ''])
+    ->condition('destid1', $nids, 'IN')
+    ->execute();
+
+  $file_storage = \Drupal::entityTypeManager()->getStorage('file');
+  foreach ($media_storage->loadMultiple($mids) as $media) {
+    $field_value = $media->get('field_media_image')->getValue();
+    $media->delete();
+    if ($file = $file_storage->load($field_value[0]['target_id'])) {
+      $file->delete();
+    }
+  }
+  \Drupal::messenger()->addMessage(t('Re-run the Person Importer to rebuild the images that were incorrectly imported the first time.'));
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Delete 1x1 images that were imported from CAP

# Need Review By (Date)
- 10/20

# Urgency
- medium

# Steps to Test
1. make sure you have the latest `stanford_profile`
1. sync the database to https://sccsd8.sites.stanford.edu/ site and see the content `/person/kate-maher`
has a black dot image.
1. run database updates and re-import the content `drush updb -y; drush mim su_stanford_person`
1. see the content again and see the image has been imported.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
