### PR TITLE
D8CORE-2002: unset "required" attribute on interests and affiliations field group.

### DIFF
--- a/config/install/core.entity_form_display.node.stanford_person.default.yml
+++ b/config/install/core.entity_form_display.node.stanford_person.default.yml
@@ -101,7 +101,7 @@ third_party_settings:
         id: ''
         classes: ''
         description: ''
-        required_fields: true
+        required_fields: false
       label: 'Interests & Affiliations'
     group_taxonomy:
       children:

--- a/stanford_person.module
+++ b/stanford_person.module
@@ -15,7 +15,6 @@ use Drupal\views\Plugin\views\cache\CachePluginBase;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_theme().
@@ -55,7 +54,7 @@ function stanford_person_page_attachments(array &$attachments) {
  * keeping cached renders much longer.
  *
  * @see stanford_person_node_presave()
- * @see stanford_person_taxonomy_term_presave()
+ * @see stanford_person_taxonomy_term_presave ()
  */
 function stanford_person_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
 
@@ -178,13 +177,4 @@ function _stanford_person_install_default_photo_file() {
   $saved = $file_system->copy($source, $destination, FileSystemInterface::EXISTS_REPLACE);
 
   return $saved;
-}
-
-/**
- * Implements hook_form_alter().
- */
-function stanford_person_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if ($form_id == 'node_stanford_person_edit_form') {
-    $form['#fieldgroups']['group_interests_affiliations']->format_settings['required_fields'] = FALSE;
-  }
 }

--- a/stanford_person.module
+++ b/stanford_person.module
@@ -15,6 +15,7 @@ use Drupal\views\Plugin\views\cache\CachePluginBase;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_theme().
@@ -54,7 +55,7 @@ function stanford_person_page_attachments(array &$attachments) {
  * keeping cached renders much longer.
  *
  * @see stanford_person_node_presave()
- * @see stanford_person_taxonomy_term_presave ()
+ * @see stanford_person_taxonomy_term_presave()
  */
 function stanford_person_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
 
@@ -177,4 +178,13 @@ function _stanford_person_install_default_photo_file() {
   $saved = $file_system->copy($source, $destination, FileSystemInterface::EXISTS_REPLACE);
 
   return $saved;
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function stanford_person_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id == 'node_stanford_person_edit_form') {
+    $form['#fieldgroups']['group_interests_affiliations']->format_settings['required_fields'] = FALSE;
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When one of the link fields in the field group has content in it, the whole field group gets marked as "required".  This corrects that problem. 

# Review By (Date)
- Code freeze.

# Criticality
- not critical.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. `drush cr`
3. Make a Person content type.
4. in the "Interests & Affiliations" field group, add a link under Links or Stanford Affiliations.
5. Notice that when you put in a URL, the Link Text gets marked as required.
6. Notice that the "Interests & Affiliations" field group as a whole does not get marked as required.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
