### PR TITLE
Pass the ps parameter when alot of sunets are to be imported

### DIFF
--- a/modules/stanford_person_importer/src/Cap.php
+++ b/modules/stanford_person_importer/src/Cap.php
@@ -176,7 +176,14 @@ class Cap implements CapInterface {
    * {@inheritDoc}
    */
   public function getSunetUrl($sunetids) {
-    return self::CAP_URL . "?uids=$sunetids";
+    $count = substr_count($sunetids, ',') + 1;
+    $url = self::CAP_URL . "?uids=$sunetids";
+    // Cap API default to 10 results. Send the argument to collect more if
+    // there are more sunets to get results for.
+    if ($count > 10) {
+      $url .= "?ps=$count";
+    }
+    return $url;
   }
 
   /**

--- a/modules/stanford_person_importer/tests/src/Unit/CapTest.php
+++ b/modules/stanford_person_importer/tests/src/Unit/CapTest.php
@@ -169,6 +169,10 @@ class CapTest extends UnitTestCase {
 
     $url = $this->service->getSunetUrl('foobarbaz');
     $this->assertEquals('https://cap.stanford.edu/cap-api/api/profiles/v1?uids=foobarbaz', $url);
+
+    $sunets = implode(',', array_fill(0, 20, 'foo'));
+    $url = $this->service->getSunetUrl($sunets);
+    $this->assertEquals("https://cap.stanford.edu/cap-api/api/profiles/v1?uids=$sunets?ps=20", $url);
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When the user configures the importer for more than 10 sunets, we need to pass the `ps` parameter to the API to get all the profiles we need.

# Need Review By (Date)
- 1/15

# Urgency
- high

# Steps to Test
1. configure the cap importer with more than 10 sunets (not workgroups or org code)
2. import the profiles
3. Verify all profiles were imported

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
